### PR TITLE
Correct capitalization of Arduino.h

### DIFF
--- a/Libraries/Arduino/src/spo2_algorithm.cpp
+++ b/Libraries/Arduino/src/spo2_algorithm.cpp
@@ -57,7 +57,7 @@
 *******************************************************************************
 */
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "spo2_algorithm.h"
 
 #if defined(ARDUINO_AVR_UNO)

--- a/Libraries/Arduino/src/spo2_algorithm.h
+++ b/Libraries/Arduino/src/spo2_algorithm.h
@@ -62,7 +62,7 @@
 #ifndef SPO2_ALGORITHM_H_
 #define SPO2_ALGORITHM_H_
 
-#include <arduino.h>
+#include <Arduino.h>
 
 #define FS 25    //sampling frequency
 #define BUFFER_SIZE (FS * 4) 


### PR DESCRIPTION
The filename was incorrectly specified as arduino.h, which causes compilation to fail on filename case sensitive operating systems such as Linux.